### PR TITLE
Add a dark theme (inspired by Bootswatch Darkly theme)

### DIFF
--- a/sass/darkly.scss
+++ b/sass/darkly.scss
@@ -1,0 +1,84 @@
+@import "settings/darkly";
+@import "components/asciidoc";
+@import "components/awesome-icons";
+@import "components/print";
+
+body {
+  background-color: $body-bg;
+  color: $primary-color;
+}
+
+#header .details {
+  font-family: $body-font-family;
+}
+
+#content {
+  font-family: $body-font-family;
+}
+
+#footer {
+  font-family: $body-font-family;
+}
+
+#toc {
+  background-color: $panel-bg;
+  padding: 1rem 1rem;
+}
+
+.admonitionblock {
+
+  &.warning > table {
+    background-color: #F39C12;
+  }
+  &.note > table {
+    background-color: #3498DB;
+  }
+  &.tip > table {
+    background-color: #00bc8c;
+  }
+  &.caution > table {
+    background-color: #E74C3C;
+  }
+  &.important > table {
+    background-color: #E74C3C;
+  }
+  & > table {
+    width: 100%;
+    border-collapse: separate;
+    border-spacing: 0;
+    border-radius: 5px;
+    border: none;
+    td.content {
+      border: 0;
+      padding: 15px;
+      code {
+        color: white;
+      }
+    }
+    td.icon {
+      & > .icon-tip:before, .icon-warning:before, .icon-important:before, .icon-caution:before, .icon-note:before {
+        text-shadow: 1px 1px 2px black;
+        color: white;
+      }
+    }
+  }
+}
+
+td.content > a {
+  font-weight: 700;
+  color: #fff;
+  text-decoration: underline;
+}
+
+table.frame-all {
+  border-collapse: collapse;
+}
+
+table.grid-all > thead > tr > .tableblock {
+  border-bottom: 2px solid #444;
+  border-top: 1px solid #444;
+}
+
+table.grid-all > tbody > tr > .tableblock {
+  border-top: 1px solid #444;
+}

--- a/sass/settings/_darkly.scss
+++ b/sass/settings/_darkly.scss
@@ -1,0 +1,76 @@
+@import "defaults";
+
+// Common
+
+$font-family: "Lato", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+
+// Body
+
+$em-base: 16px;
+$global-radius: 0;
+$body-font-family: $font-family;
+$body-font-color: #222;
+$body-bg: #222;
+$primary-color: white;
+
+// Headings
+
+$title-font-color: white;
+$header-font-color: white;
+$header-font-family: $font-family;
+$header-top-margin: 1em;
+$sect-divider-size: 1px;
+$sect-divider-style: solid;
+$sect-divider-color: #444;
+
+// Panels
+
+$panel-bg: #303030;
+
+// Paragraphs
+
+// Code
+
+$code-color: #e83e8c;
+$code-font-family: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+
+$pre-font-size: .9em;
+$pre-font-family: monospace, serif;
+$pre-bg: #303030;
+$pre-line-height: 1.4;
+$pre-border-size: 1px;
+$pre-border-color: #444;
+$pre-border-style: solid;
+$pre-font-color: #e83e8c;
+$pre-padding: .8em .8em .65em .8em;
+
+// Links
+
+$anchor-font-color: #00bc8c;
+$anchor-font-color-hover: #007053;
+
+// Lists
+
+$list-side-margin: emCalc(24px);
+$definition-list-header-margin-bottom: emCalc(5px);
+$definition-list-margin-bottom: emCalc(20px);
+
+// Blockquotes
+
+// Tables
+
+$table-border-size: 0;
+$table-head-font-color: white;
+$table-bg: rgba(0, 0, 0, 0.075);
+$table-even-row-bg: rgba(0, 0, 0, 0.075);
+$table-head-bg: rgba(0, 0, 0, 0.075);
+$table-head-font-size: inherit;
+$table-row-font-size: inherit;
+$table-line-height: 1.4;
+$table-row-font-color: white;
+
+// Footer
+
+$footer-bg: #303030;
+$footer-font-color: white;
+


### PR DESCRIPTION
Dark theme inspired by [Darkly](https://bootswatch.com/darkly/) as requested in https://github.com/asciidoctor/asciidoctor-stylesheet-factory/issues/22

![dark-theme](https://user-images.githubusercontent.com/333276/42728767-c0feb948-87c2-11e8-8d17-7b7540c49dfc.png)

In the above screenshot, I'm using the Highlight.js theme named `gruvbox-dark`.
Here's another screenshot with admonitions:
![dark-theme-admo](https://user-images.githubusercontent.com/333276/42728765-bf02e25e-87c2-11e8-9412-7723faa0ee14.png)

And another one with a table:
![dark-theme-table](https://user-images.githubusercontent.com/333276/42728766-bfc925f4-87c2-11e8-9cb5-b00a8b16f75f.png)

